### PR TITLE
feat/#29: 뉴스 학습 시 learningDate 업데이트

### DIFF
--- a/seed/newsHistorySeed.js
+++ b/seed/newsHistorySeed.js
@@ -40,7 +40,7 @@ const newsHistorySeed = async () => {
         title: row.title,
         imgUrl: row.imgUrl,
         category: row.category,
-        learningDate: "2025-09-09", // 현재 날짜로 임시 지정
+        learningDate: new Date().toISOString().split("T")[0], // 현재 날짜
         isCorrect: null, // 아직 채점 전
       })),
     };

--- a/src/controllers/monNewsController.js
+++ b/src/controllers/monNewsController.js
@@ -1,4 +1,5 @@
 const { getStudentIdFromToken } = require("../auth/token");
+const NewsHistory = require("../models/newsHistory");
 
 // 테스트용 더미 데이터
 const dummyMonNews = [
@@ -37,10 +38,31 @@ exports.getTodayMonNews = (req, res) => {
 };
 
 // [post] 오늘의 monNews 완료
-exports.postTodayMonNewsDone = (req, res) => {
-  const studentId = getStudentIdFromToken(req) || 1; // 테스트용 디폴트
-  const today = new Date().toISOString().split("T")[0];
+exports.postTodayMonNewsDone = async (req, res) => {
+  try {
+    const studentId = getStudentIdFromToken(req) || 1; // 테스트용 디폴트
+    const today = new Date().toISOString().split("T")[0];
+    const { newsId } = req.body;
 
-  // console.log(`학생 ${studentId}의 ${today} 뉴스 학습 완료!`);
-  res.json({ message: "오늘 Mon 뉴스 학습 완료!" });
+    // 뉴스 히스토리에 학습 기록 추가
+    await NewsHistory.updateOne(
+      { studentId },
+      {
+        $push: {
+          newsList: {
+            newsId,
+            learningDate: today, // 학습 완료 날짜
+            isCorrect: null,
+          },
+        },
+      },
+      { upsert: true }
+    );
+
+    // console.log(`학생 ${studentId}의 ${today} 뉴스 학습 완료!`);
+    res.json({ message: "오늘 MON 뉴스 학습 완료!", learningDate: today });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "뉴스 학습 완료 처리 실패" });
+  }
 };


### PR DESCRIPTION
📌 close #29 
퀴즈까지 완료해야 히스토리로 이동 
학습날짜 = 퀴즈날짜이므로 히스토리 안의 learningDate는 학습날짜로 설정 

📝 **postTodayMonNewsDone** 수정해서 학습 완료 시 newsHistory의 learningDate가 업데이트되도록 설정 

```
// [post] 오늘의 monNews 완료
exports.postTodayMonNewsDone = async (req, res) => {
  try {
    const studentId = getStudentIdFromToken(req) || 1; // 테스트용 디폴트
    const today = new Date().toISOString().split("T")[0];
    const { newsId } = req.body;

    // 뉴스 히스토리에 학습 기록 추가
    await NewsHistory.updateOne(
      { studentId },
      {
        $push: {
          newsList: {
            newsId,
            learningDate: today, // 학습 완료 날짜
            isCorrect: null,
          },
        },
      },
      { upsert: true }
    );
```


