### PR TITLE
Feat/#31/history api

### DIFF
--- a/seed/quizResultSeed.js
+++ b/seed/quizResultSeed.js
@@ -1,0 +1,52 @@
+require("dotenv").config();
+const mysql = require("mysql2/promise");
+const connectDB = require("../src/config/db");
+const quizResult = require("../src/models/quizResult");
+
+const quizResultSeed = async () => {
+  try {
+    // 1. MongoDB 연결
+    await connectDB();
+
+    // 2. MySQL 원격 서버 연결
+    const connection = await mysql.createConnection({
+      host: process.env.MYSQL_HOST,
+      port: process.env.MYSQL_PORT,
+      user: process.env.MYSQL_USER,
+      password: process.env.MYSQL_PASSWORD,
+      database: process.env.MYSQL_DB,
+    });
+
+    console.log("MySQL 연결 성공!");
+
+    // 3. 필요한 데이터 쿼리
+    const [rows] = await connection.execute(`
+      SELECT 
+        mq_id AS quizId,
+      FROM mon_quiz_items
+      LIMIT 100 OFFSET 0
+    `);
+
+    // 4. MongoDB용으로 변환
+    const quizResultData = {
+      studentId: 1, // 필요시 수정
+      results: rows.map((row) => ({
+        quizId: row.quizId,
+        day: new Date().toISOString().split("T")[0], // 현재 날짜
+        score: null, // 이후에 isCorrect로 계산하기!!!
+      })),
+    };
+
+    // 5. MongoDB에 저장
+    await quizResult.deleteMany({ studentId: 1 });
+    await quizResult.insertMany(quizResultData);
+
+    console.log("MongoDB 퀴즈 성적 데이터 삽입 완료!");
+    process.exit();
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+};
+
+quizResultSeed();

--- a/seed/seriesHistorySeed.js
+++ b/seed/seriesHistorySeed.js
@@ -1,0 +1,75 @@
+require("dotenv").config();
+const mysql = require("mysql2/promise");
+const connectDB = require("../src/config/db");
+const SeriesHistory = require("../src/models/seriesHistory");
+
+const seriesHistorySeed = async () => {
+  try {
+    // 1. MongoDB 연결
+    await connectDB();
+
+    // 2. MySQL 원격 서버 연결
+    const connection = await mysql.createConnection({
+      host: process.env.MYSQL_HOST,
+      port: process.env.MYSQL_PORT,
+      user: process.env.MYSQL_USER,
+      password: process.env.MYSQL_PASSWORD,
+      database: process.env.MYSQL_DB,
+    });
+
+    console.log("MySQL 연결 성공!");
+
+    // 3. 필요한 데이터 쿼리
+    const [rows] = await connection.execute(`
+      SELECT 
+        m.ms_id AS seriesId,
+        m.title AS title,
+        m.main_keyword AS keyword,
+        MIN(o.img_url) AS imgUrl
+      FROM mon_series m
+      LEFT JOIN mon_series_articles s
+        ON m.ms_id = s.ms_id
+      LEFT JOIN org_article_tb o
+        ON s.oa_id = o.oa_id
+      GROUP BY m.ms_id, m.title, m.main_keyword
+      LIMIT 100 OFFSET 0
+    `);
+
+    // 4. MongoDB용으로 변환
+    const seriesHistoryData = {
+      studentId: 1, // 필요시 수정
+      seriesList: rows.map((row) => {
+        const parts = [
+          {
+            partId: row.partId,
+            isLearned: false,
+            part_title: row.p_title,
+            part_sub_title: row.p_sub_title,
+          },
+        ];
+
+        return {
+          ...row, // 기존값 유지
+          sub_title: row.sub_title,
+          status: row.practice ?? "ongoing",
+          learningDate: new Date().toISOString().split("T")[0],
+          totalCount: parts.length,
+          learnedCount: parts.filter((p) => p.isLearned).length,
+          parts,
+        };
+      }),
+    };
+
+    // 5. MongoDB에 저장
+    await SeriesHistory.deleteMany({ studentId: 1 });
+    await SeriesHistory.insertMany(seriesHistoryData);
+
+    console.log("MongoDB 시리즈 히스토리 데이터 삽입 완료!");
+    process.exit();
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+};
+
+seriesHistorySeed();

--- a/seed/seriesHistorySeed.js
+++ b/seed/seriesHistorySeed.js
@@ -23,41 +23,60 @@ const seriesHistorySeed = async () => {
     const [rows] = await connection.execute(`
       SELECT 
         m.ms_id AS seriesId,
-        m.title AS title,
+        m.title AS seriesTitle,
+        m.subtitle AS seriesSubTitle
         m.main_keyword AS keyword,
         MIN(o.img_url) AS imgUrl
+
+        s.oa_id AS partId,
+        o.title AS part_title,
+        o.subtitle AS part_sub_title,
+        o.img_url AS part_img_url
       FROM mon_series m
       LEFT JOIN mon_series_articles s
         ON m.ms_id = s.ms_id
       LEFT JOIN org_article_tb o
         ON s.oa_id = o.oa_id
-      GROUP BY m.ms_id, m.title, m.main_keyword
+      GROUP BY 
+        m.ms_id, m.title, m.subtitle, m.main_keyword,
+        s.oa_id, o.title, o.subtitle, o.img_url
       LIMIT 100 OFFSET 0
     `);
 
     // 4. MongoDB용으로 변환
-    const seriesHistoryData = {
-      studentId: 1, // 필요시 수정
-      seriesList: rows.map((row) => {
-        const parts = [
-          {
-            partId: row.partId,
-            isLearned: false,
-            part_title: row.p_title,
-            part_sub_title: row.p_sub_title,
-          },
-        ];
+    const seriesMap = {};
 
-        return {
-          ...row, // 기존값 유지
+    rows.forEach((row) => {
+      if (!seriesMap[row.seriesId]) {
+        seriesMap[row.seriesId] = {
+          seriesId: row.seriesId,
+          title: row.title,
           sub_title: row.sub_title,
-          status: row.practice ?? "ongoing",
+          keyword: row.keyword,
+          status: "ongoing",
           learningDate: new Date().toISOString().split("T")[0],
-          totalCount: parts.length,
-          learnedCount: parts.filter((p) => p.isLearned).length,
-          parts,
+          imgUrl: row.imgUrl,
+          parts: [],
         };
-      }),
+      }
+
+      if (row.partId) {
+        seriesMap[row.seriesId].parts.push({
+          partId: row.partId,
+          isLearned: false,
+          part_title: row.p_title,
+          part_sub_title: row.p_sub_title,
+        });
+      }
+
+      const s = seriesMap[row.seriesId];
+      s.totalCount = s.parts.length;
+      s.learnedCount = s.parts.filter((p) => p.isLearned).length;
+    });
+
+    const seriesHistoryData = {
+      studentId: 1,
+      seriesList: Object.values(seriesMap),
     };
 
     // 5. MongoDB에 저장

--- a/seed/wordHistorySeed.js
+++ b/seed/wordHistorySeed.js
@@ -1,0 +1,58 @@
+require("dotenv").config();
+const mysql = require("mysql2/promise");
+const connectDB = require("../src/config/db");
+const WordHistory = require("../src/models/wordHistory");
+
+const wordHistorySeed = async () => {
+  try {
+    // 1. MongoDB 연결
+    await connectDB();
+
+    // 2. MySQL 원격 서버 연결
+    const connection = await mysql.createConnection({
+      host: process.env.MYSQL_HOST,
+      port: process.env.MYSQL_PORT,
+      user: process.env.MYSQL_USER,
+      password: process.env.MYSQL_PASSWORD,
+      database: process.env.MYSQL_DB,
+    });
+
+    console.log("MySQL 연결 성공!");
+
+    // 3. 필요한 데이터 쿼리
+    const [rows] = await connection.execute(`
+      SELECT 
+        mw_id AS wordId,
+        word,
+        meaning,
+        practice
+      FROM mon_word_items
+      LIMIT 100 OFFSET 0
+    `);
+
+    // 4. MongoDB용으로 변환
+    const wordHistoryData = {
+      studentId: 1, // 필요시 수정
+      words: rows.map((row) => ({
+        wordId: row.wordId,
+        word: row.word,
+        explain: row.meaning,
+        use: row.practice,
+        learningDate: new Date().toISOString().split("T")[0], // 현재 날짜
+        isCorrect: null, // 아직 채점 전
+      })),
+    };
+
+    // 5. MongoDB에 저장
+    await WordHistory.deleteMany({ studentId: 1 });
+    await WordHistory.insertMany(wordHistoryData);
+
+    console.log("MongoDB 단어 히스토리 데이터 삽입 완료!");
+    process.exit();
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+};
+
+wordHistorySeed();

--- a/src/controllers/attendanceController.js
+++ b/src/controllers/attendanceController.js
@@ -2,27 +2,30 @@ const { getStudentIdFromToken } = require("../auth/token");
 const Attendance = require("../models/attendance");
 const { getWeekRange } = require("../utils/week");
 
+function formatKSTDate(date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(
+    date.getDate()
+  ).padStart(2, "0")}`;
+}
+
 // 오늘 출석 처리
 exports.todayAttendance = async (req, res) => {
   const studentId = getStudentIdFromToken(req) || 1;
+  const today = new Date();
+  // 오늘 날짜 문자열(KST)
+  const todayStr = formatKSTDate(today);
 
   try {
-    const today = new Date();
-    const todayStr = today.toISOString().split("T")[0]; // YYYY-MM-DD
-
     let attendance = await Attendance.findOne({ studentId });
     if (!attendance) attendance = new Attendance({ studentId, days: [] });
 
-    // 오늘 날짜 기존 기록 찾기
-    const existingDay = attendance.days.find(
-      (d) => new Date(d.day).toISOString().split("T")[0] === todayStr
-    );
+    const existing = attendance.days.find((d) => formatKSTDate(new Date(d.day)) === todayStr);
 
-    if (existingDay) existingDay.isAttended = true; // 오늘 기록 이미 있으면 true
-    else attendance.days.push({ day: today, isAttended: true }); // 없으면 새로 추가
+    if (existing) existing.isAttended = true;
+    else attendance.days.push({ day: today, isAttended: true });
 
     await attendance.save();
-    res.json({ message: "오늘 출석 완료!", day: today });
+    res.json({ message: "오늘 출석 완료!", day: today.toISOString().split("T")[0] });
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: "출석 처리 중 오류 발생" });
@@ -32,29 +35,22 @@ exports.todayAttendance = async (req, res) => {
 // 특정 주차 출석 조회
 exports.getAttendanceByWeek = async (req, res) => {
   const studentId = getStudentIdFromToken(req) || 1;
-  const weekQuery = req.query.week; // "이번주" or "저번주"
+  const weekQuery = req.query.week;
 
   try {
     const attendance = await Attendance.findOne({ studentId });
     if (!attendance) return res.json({ days: [] });
 
-    // 문자열 기준으로 날짜 범위 계산
     const { weekStart, weekEnd } = getWeekRange(weekQuery);
-
-    function formatKSTDate(date) {
-      return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(
-        date.getDate()
-      ).padStart(2, "0")}`;
-    }
-
     const daysInWeek = [];
+
     for (let d = new Date(weekStart); d <= weekEnd; d.setDate(d.getDate() + 1)) {
-      const isoDay = formatKSTDate(d);
-      // DB의 day와 문자열 비교
-      const found = attendance.days.find(
-        (a) => new Date(a.day).toISOString().split("T")[0] === isoDay
-      );
-      daysInWeek.push(found || { day: isoDay, isAttended: false });
+      const dayStr = formatKSTDate(d);
+      const found = attendance.days.find((a) => formatKSTDate(new Date(a.day)) === dayStr);
+      daysInWeek.push({
+        day: dayStr,
+        isAttended: found ? found.isAttended : false,
+      });
     }
 
     res.json({ days: daysInWeek });

--- a/src/controllers/monNewsController.js
+++ b/src/controllers/monNewsController.js
@@ -52,7 +52,6 @@ exports.postTodayMonNewsDone = async (req, res) => {
           newsList: {
             newsId,
             learningDate: today, // 학습 완료 날짜
-            isCorrect: null,
           },
         },
       },

--- a/src/controllers/quizResultController.js
+++ b/src/controllers/quizResultController.js
@@ -1,38 +1,13 @@
 const { getStudentIdFromToken } = require("../auth/token");
-//const QuizResult = require("../models/quizResult");
+const QuizResult = require("../models/quizResult");
 const { getWeekRange } = require("../utils/week");
-
-const DummyQuizResult = {
-  findOne: async ({ studentId }) => {
-    return {
-      studentId,
-      results: [
-        {
-          quizId: "quiz-001",
-          day: "2025-09-08",
-          score: 80,
-        },
-        {
-          quizId: "quiz-002",
-          day: "2025-09-09",
-          score: 60,
-        },
-        {
-          quizId: "quiz-003",
-          day: "2025-09-10",
-          score: 90,
-        },
-      ],
-    };
-  },
-};
 
 exports.getQuizResultByWeek = async (req, res) => {
   const studentId = getStudentIdFromToken(req) || 123;
   const weekQuery = req.query.week;
 
   try {
-    const result = await DummyQuizResult.findOne({ studentId });
+    const result = await QuizResult.findOne({ studentId });
     if (!result)
       return res.status(404).json({ message: "해당 학생의 퀴즈 성적 데이터가 없습니다." });
 

--- a/src/controllers/seriesHistoryController.js
+++ b/src/controllers/seriesHistoryController.js
@@ -1,42 +1,13 @@
 const { getStudentIdFromToken } = require("../auth/token");
-//const SeriesHistory = require("../models/seriesHistory");
+const SeriesHistory = require("../models/seriesHistory");
 const { getWeekRange } = require("../utils/week");
-
-const DummySeriesHistory = {
-  findOne: async ({ studentId }) => {
-    return {
-      studentId,
-      seriesList: [
-        {
-          seriesId: 1,
-          title: "시리즈 제목",
-          sub_title: "시리즈 부제목",
-          keyword: "시리즈 부제목",
-          status: "ongoing",
-          learningDate: "2025-09-09",
-          totalCount: 10,
-          learnedCount: 7,
-          imgUrl: "",
-          parts: [
-            {
-              partId: 101,
-              isLearned: true,
-              part_title: "제목",
-              part_sub_title: "부제목",
-            },
-          ],
-        },
-      ],
-    };
-  },
-};
 
 exports.getSeriesHistory = async (req, res) => {
   const studentId = getStudentIdFromToken(req) || 1;
   const weekQuery = req.query.week;
 
   try {
-    const seriesData = await DummySeriesHistory.findOne({ studentId });
+    const seriesData = await SeriesHistory.findOne({ studentId });
     if (!seriesData)
       return res.status(404).json({ message: "해당 학생의 시리즈 데이터가 없습니다." });
 

--- a/src/controllers/wordHistoryController.js
+++ b/src/controllers/wordHistoryController.js
@@ -1,32 +1,13 @@
 const { getStudentIdFromToken } = require("../auth/token");
-//const WordHistory = require("../models/wordHistory");
+const WordHistory = require("../models/wordHistory");
 const { getWeekRange } = require("../utils/week");
-
-const DummyWordHistory = {
-  findOne: async ({ studentId }) => {
-    return {
-      studentId,
-      words: [
-        {
-          wordId: 1,
-          category: "MONEY",
-          word: "제목",
-          explain: "설명",
-          use: "써먹기",
-          learningDate: "2025-09-05",
-          isCorrect: true,
-        },
-      ],
-    };
-  },
-};
 
 exports.getWordHistory = async (req, res) => {
   const studentId = getStudentIdFromToken(req) || 1;
   const weekQuery = req.query.week;
 
   try {
-    const wordData = await DummyWordHistory.findOne({ studentId });
+    const wordData = await WordHistory.findOne({ studentId });
     if (!wordData) return res.status(404).json({ message: "해당 학생의 단어 데이터가 없습니다." });
 
     const { weekStart, weekEnd } = getWeekRange(weekQuery);

--- a/src/models/seriesHistory.js
+++ b/src/models/seriesHistory.js
@@ -12,7 +12,7 @@ const seriesHistorySchema = new mongoose.Schema({
       learningDate: { type: Date, required: true },
       totalCount: { type: Number, required: true },
       learnedCount: { type: Number, required: true },
-      imgUrl: { type: String, required: true },
+      imgUrl: { type: String, default: null },
       parts: [
         {
           partId: { type: String, required: true },

--- a/src/models/wordHistory.js
+++ b/src/models/wordHistory.js
@@ -10,7 +10,7 @@ const wordSchema = new mongoose.Schema({
       explain: { type: String, required: true },
       use: { type: String, required: true },
       learningDate: { type: Date, required: true },
-      isCorrect: { type: Boolean, required: true },
+      isCorrect: { type: Boolean, default: null },
     },
   ],
 });


### PR DESCRIPTION
close #31 

지금 db 받아오는 게 안돼서 일단 한 것과 계획 !!

✅ 완료한 것 ,, 
-> 단어 히스토리 / 시리즈 히스토리 / 퀴즈 결과 seed 생성하고 
오늘 조회하면 바로 출석처리되고 db에 출석 현황 저장되도록 설정해놓음 

 🔥 **db연결 계획**
1. progress 
    뉴스/단어/시리즈 학습 후 post로 완료한 거 보내면 progress DB 연결할 것 

2. quizResult 
    퀴즈 성적은 퀴즈 푼 후에 isCorrect 받아와서 score 계산하기 
    
3. weakness 
    약점은 백에서 AI로 데이터 보내고 mysql로 받아온 후에 연결할 것 !
    
4. seriesHistory / wordHistory
    db연결되면 둘 다 잘 작동하는지 확인해보기 + 시리즈는 칼럼 더 추가(part_title, sub_title 등등) 

