### PR TITLE
feat/#48: weakness API 수정

### DIFF
--- a/src/controllers/monQuizController.js
+++ b/src/controllers/monQuizController.js
@@ -46,6 +46,36 @@ const getStudentIdFromToken = (req) => {
   }
 };
 
+// mon_quiz_id로 category 가져오기
+const getCategoryByQuiz = async (mq_id) => {
+  const result = await MonQuiz.aggregate([
+    { $match: { mq_id } }, // mon_quiz에서 mq_id
+    {
+      $lookup: {
+        from: "mon_news", // mon_news
+        localField: "mn_id",
+        foreignField: "mn_id",
+        as: "news",
+      },
+    },
+    { $unwind: "$news" },
+    {
+      $lookup: {
+        from: "org_article_tb", // org_article_tb
+        localField: "news.oa_id",
+        foreignField: "oa_id",
+        as: "article",
+      },
+    },
+    { $unwind: "$article" },
+    { $project: { category: "$article.category", _id: 0 } },
+  ]);
+
+  if (!result.length) throw new Error("Category not found");
+
+  return result[0].category;
+};
+
 // [get] 오늘의 monQuiz 조회
 exports.getTodayMonQuiz = (req, res) => {
   const studentId = getStudentIdFromToken(req) || 123; // 테스트용 디폴트
@@ -141,6 +171,23 @@ exports.postMonQuizSubmit = async (req, res) => {
           day: today,
           score: percentageScore,
         })),
+      },
+    },
+    { upsert: true }
+  );
+
+  // weakness 컬렉션에 저장
+  const category = await getCategoryByQuiz(mq_id);
+
+  await Weakness.updateOne(
+    { studentId, date: getWeekStart(today) },
+    {
+      $push: {
+        categories: {
+          category,
+          total: totalQuizzes,
+          correct: correctCount,
+        },
       },
     },
     { upsert: true }

--- a/src/controllers/monQuizController.js
+++ b/src/controllers/monQuizController.js
@@ -193,6 +193,15 @@ exports.postMonQuizSubmit = async (req, res) => {
           },
           summary: null,
         },
+        weakNews: {
+          date: weekEnd,
+          categories: {
+            category,
+            total: totalQuizzes,
+            correct: correctCount,
+          },
+          summary: null,
+        },
       },
     },
     { upsert: true }

--- a/src/controllers/monQuizController.js
+++ b/src/controllers/monQuizController.js
@@ -177,16 +177,21 @@ exports.postMonQuizSubmit = async (req, res) => {
   );
 
   // weakness 컬렉션에 저장
+  const { weekEnd } = getWeekRange("이번주");
   const category = await getCategoryByQuiz(mq_id);
 
   await Weakness.updateOne(
-    { studentId, date: getWeekStart(today) },
+    { studentId },
     {
       $push: {
-        categories: {
-          category,
-          total: totalQuizzes,
-          correct: correctCount,
+        weakWord: {
+          date: weekEnd,
+          categories: {
+            category,
+            total: totalQuizzes,
+            correct: correctCount,
+          },
+          summary: null,
         },
       },
     },

--- a/src/controllers/weaknessController.js
+++ b/src/controllers/weaknessController.js
@@ -9,12 +9,13 @@ const DummyWeakness = {
       studentId,
       weakWord: [
         {
-          date: "2025-09-01", // 해당 주의 시작일
+          date: "2025-09-14", // 전 주 일요일에 보내는 걸로 !
           categories: [
             { category: "MONEY", total: 10, correct: 7 },
             { category: "GLOBAL", total: 5, correct: 4 },
             { category: "BIGPICTURE", total: 8, correct: 3 },
             { category: "ISSUES", total: 7, correct: 3 },
+            { category: "TECH", total: 7, correct: 3 },
           ],
           summary:
             "특히 거시경제와 정책/이슈에서 틀린 개수가 많아요. 이번 주에는 이 두 분야를 집중적으로 학습하면 좋겠어요!",
@@ -22,12 +23,12 @@ const DummyWeakness = {
       ],
       weakNews: [
         {
-          date: "2025-09-01", // 해당 주의 시작일
+          date: "2025-09-14",
           categories: [
             { category: "TECH", total: 10, correct: 7 },
             { category: "GLOBAL", total: 5, correct: 4 },
-            { category: "BIGPICTURE", total: 8, correct: 3 },
-            { category: "ISSUES", total: 7, correct: 3 },
+            { category: "BIGPICTURE", total: 8, correct: 5 },
+            { category: "ISSUES", total: 7, correct: 5 },
           ],
           summary:
             "특히 거시경제와 정책/이슈에서 틀린 개수가 많아요. 이번 주에는 이 두 분야를 집중적으로 학습하면 좋겠어요!",
@@ -48,13 +49,31 @@ exports.getWeaknessByWeek = async (req, res) => {
     const { weekStart } = getWeekRange(weekQuery);
     const weekStartStr = weekStart.toISOString().split("T")[0];
 
-    // weekStart와 일치하는 데이터 하나 가져오기
+    // 임계값
+    const threshold = 50;
+
+    // week, 임계값 조건에 맞는 데이터 필터링
     const weekWeakWord = weakness.weakWord.find((w) => w.date === weekStartStr);
+    const filteredWordCategories = weekWeakWord
+      ? weekWeakWord.categories.filter((c) => (c.correct / c.total) * 100 < threshold)
+      : [];
+
     const weekWeakNews = weakness.weakNews.find((w) => w.date === weekStartStr);
+    const filteredNewsCategories = weekWeakNews
+      ? weekWeakNews.categories.filter((c) => (c.correct / c.total) * 100 < threshold)
+      : [];
 
     res.json({
-      weakWord: weekWeakWord || null,
-      weakNews: weekWeakNews || null,
+      weakWord: {
+        date: weekStartStr,
+        summary: weekWeakWord?.summary || null,
+        categories: filteredWordCategories,
+      },
+      weakNews: {
+        date: weekStartStr,
+        summary: weekWeakNews?.summary || null,
+        categories: filteredNewsCategories,
+      },
     });
   } catch (err) {
     console.error(err);

--- a/src/models/weakness.js
+++ b/src/models/weakness.js
@@ -15,6 +15,19 @@ const weaknessSchema = new mongoose.Schema({
       summary: { type: String, default: null },
     },
   ],
+  weakNews: [
+    {
+      date: { type: Date, required: true }, // 해당 주의 시작일
+      categories: [
+        {
+          category: { type: String, required: true },
+          total: { type: Number, required: true },
+          correct: { type: Number, required: true },
+        },
+      ],
+      summary: { type: String, default: null },
+    },
+  ],
 });
 
 module.exports = mongoose.model("Weakness", weaknessSchema);


### PR DESCRIPTION
## 📌 Related Issue

close #48 

## ✨ Work Description

약점 분석 API 설계 
퀴즈 학습 후 category 추출하고 정답률 계산 
임계값 조건 추가하여 조건 만족한 값만 categories 배열에 데이터 포함하여 전송 

postMonQuizSubmit에 추가 
```
// weakness 컬렉션에 저장
  const { weekEnd } = getWeekRange("이번주");
  const category = await getCategoryByQuiz(mq_id);

  await Weakness.updateOne(
    { studentId },
    {
      $push: {
        weakWord: {
          date: weekEnd,
          categories: {
            category,
            total: totalQuizzes,
            correct: correctCount,
          },
         weakNews: {
          date: weekEnd,
          categories: {
            category,
            total: totalQuizzes,
            correct: correctCount,
          },
          summary: null,
        },
          summary: null,
        },
      },
    },
    { upsert: true }
  );
```

현재 더미데이터
```
weakWord: [
        {
          date: "2025-09-14", // 전 주 일요일에 보내는 걸로 !
          categories: [
            { category: "MONEY", total: 10, correct: 7 },
            { category: "GLOBAL", total: 5, correct: 4 },
            { category: "BIGPICTURE", total: 8, correct: 3 },
            { category: "ISSUES", total: 7, correct: 3 },
            { category: "TECH", total: 7, correct: 3 },
          ],
          summary:
            "특히 거시경제와 정책/이슈에서 틀린 개수가 많아요. 이번 주에는 이 두 분야를 집중적으로 학습하면 좋겠어요!",
        },
      ],
```
퀴즈 학습 후 그 주의 마지막 날을 date로 저장 
왜냐 !! 
(예시 : 퀴즈를 9/9에 봄 -> date는 그 주의 마지막 날인 9/14를 저장 -> 새로운 주 시작인 9/15에 데이터를 불러올 때는 
14일의 데이터들을 불러옴) 

## ✨ 앞으로..
Summary 값 생성되면 한 번 더 수정할 예정 