### PR TITLE
Feat/46/monNews 배정/조회/완료처리 API 구현

### DIFF
--- a/src/controllers/monNewsController.js
+++ b/src/controllers/monNewsController.js
@@ -1,26 +1,35 @@
 const DailyNews = require("../models/daily/dailyNews");
 const StudentNews = require("../models/monNews");
+const Student = require("../models/student");
 const { formatDate } = require("../utils/date");
 const { getUserIdFromToken } = require("../utils/auth");
 
 // [POST] 학생에게 오늘 뉴스 배정 (level)
 exports.assignLevelToStudent = async (req, res) => {
   try {
-    const studentId = getUserIdFromToken(req, "student" | 1);
+    const studentId = getUserIdFromToken(req, "student");
 
     if (!studentId)
-      return res.status(404).json({ message: "MONDAY 유저가 아닙니다." });
+      return res.status(401).json({ message: "인증되지 않은 사용자입니다." });
 
-    const { level } = req.body; // body에서 받도록 (params도 가능)
+    // studentId로 DB에서 회원 조회 (비밀번호 제외)
+    const studentInfo = await Student.findById(studentId).select("-password");
+    if (!studentInfo)
+      return res.status(404).json({ message: "학생 정보가 없습니다." });
+
+    // 회원의 level 값 (없으면 1로 기본 세팅)
+    const level = studentInfo.level || "씨앗";
     const dateStr = formatDate(new Date());
 
     // ① 오늘 날짜 + 해당 레벨 뉴스 가져오기
     // const docs = await DailyNews.find({ date: dateStr, level }).lean();
 
     // ② 오늘 날짜 + 해당 레벨 뉴스 가져오기 (가장 최신 데이터 1개 가져오기)
-    const docs = await DailyNews.find({ level, date: dateStr }).sort({
-      date: -1,
-    });
+    const docs = await DailyNews.find({ level, date: dateStr })
+      .sort({
+        date: -1,
+      })
+      .lean();
 
     if (!docs.length) {
       return res

--- a/src/controllers/monNewsController.js
+++ b/src/controllers/monNewsController.js
@@ -22,14 +22,14 @@ exports.assignLevelToStudent = async (req, res) => {
     const dateStr = formatDate(new Date());
 
     // ① 오늘 날짜 + 해당 레벨 뉴스 가져오기
-    // const docs = await DailyNews.find({ date: dateStr, level }).lean();
+    const docs = await DailyNews.find({ date: dateStr, level }).lean();
 
-    // ② 오늘 날짜 + 해당 레벨 뉴스 가져오기 (가장 최신 데이터 1개 가져오기)
-    const docs = await DailyNews.find({ level, date: dateStr })
-      .sort({
-        date: -1,
-      })
-      .lean();
+    // ② 테스트용 - 가장 최신 날짜 / 해당 레벨 1개 가져오기
+    // const docs = await DailyNews.find({ level, date: dateStr })
+    //   .sort({
+    //     date: -1,
+    //   })
+    //   .lean();
 
     if (!docs.length) {
       return res
@@ -161,5 +161,37 @@ exports.postTodayMonNewsDone = async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: "뉴스 학습 완료 처리 실패" });
+  }
+};
+
+exports.getMonNewsSubmit = async (req, res) => {
+  try {
+    const studentId = getUserIdFromToken(req, "student") || 1;
+    const today = formatDate(new Date());
+
+    const student = await StudentNews.findOne({ studentId }).lean();
+    if (!student)
+      return res.status(404).json({ message: "오늘 뉴스가 없습니다." });
+
+    const todayNews = student.newsList.filter(
+      (item) => formatDate(item.assignedAt) === today
+    );
+
+    if (!todayNews.length)
+      return res.status(404).json({ message: "오늘 뉴스가 없습니다." });
+
+    res.json({
+      result: todayNews.map((news) => ({
+        id: news.mnId,
+        title: news.title,
+        body: news.body,
+        summary: news.summary,
+        imgUrl: news.imgUrl,
+        level: news.level,
+      })),
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "오늘 뉴스 조회 실패" });
   }
 };

--- a/src/controllers/studentMainController.js
+++ b/src/controllers/studentMainController.js
@@ -1,6 +1,3 @@
-const { response } = require("express");
-const jwt = require("jsonwebtoken");
-
 // 테스트용 더미 데이터
 // monWord
 const dummyMonWord = [
@@ -29,34 +26,6 @@ const dummyMonWord = [
   },
 ];
 
-// monNews
-const dummyMonNews = [
-  {
-    id: 1,
-    studentId: 123,
-    learningDate: new Date().toISOString().split("T")[0], // 항상 오늘로 설정
-    title: "햄버거 값 또 올랐다! 인플레이션으로 물가 상승이 계속될까?",
-    body: `"요즘 햄버거 가게에 가면 깜짝 놀라는 사람들이 많아요. 작년에는 5,500원이던 햄버거 세트가 올해는 6,500원이 되었기 때문이에요. 왜 이렇게 가격이 오르는 걸까요?\n\n이것은 바로 인플레이션 때문이에요. 인플레이션은 물건 값이 전반적으로 올라가는 현상을 말해요. 요즘은 고기, 빵, 채소 같은 재료 가격도 오르고, 직원들 월급도 올라서 음식점들이 가격을 올릴 수밖에 없어요.\n\n전문가들은 \"지금은 전 세계적으로 인플레이션이 계속되고 있어요. 물가가 안정될 때까지는 가격이 더 오를 수도 있어요.\"라고 말했어요.\n\n소비자들은 \"예전에는 같은 돈으로 더 많이 먹을 수 있었는데, 이제는 부담돼요.\"라며 걱정하고 있어요.\n\n여러분도 최근에 가격이 올라서 놀란 물건이 있나요? 🤔"`,
-    summary:
-      "최근 인플레이션 때문에 햄버거 값이 올라서 사람들이 부담을 느끼고 있어요",
-    createdAt: new Date().toISOString().split("T")[0],
-  },
-];
-
-// 토큰에서 studentId 추출
-const getStudentIdFromToken = (req) => {
-  const authHeader = req.headers["authorization"];
-  if (!authHeader) return null;
-
-  const token = authHeader.split(" ")[1];
-  try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET);
-    return decoded.studentId;
-  } catch (err) {
-    console.error(err);
-  }
-};
-
 // [get] 학생 메인 monWord 조회
 exports.getStdMonWord = (req, res) => {
   const studentId = getStudentIdFromToken(req) || 123; // 테스트용 디폴트
@@ -81,23 +50,63 @@ exports.getStdMonWord = (req, res) => {
   });
 };
 
-// [get] 학생 메인 monNews 조회
-exports.getStdMonNews = (req, res) => {
-  const studentId = getStudentIdFromToken(req) || 123; // 테스트용 디폴트
-  const today = new Date().toISOString().split("T")[0];
+const jwt = require("jsonwebtoken");
+const StudentNews = require("../models/monNews");
+const { formatDate } = require("../utils/date");
 
-  // 오늘 데이터 찾기
-  const todayNews = dummyMonNews.find(
-    (item) => item.studentId === studentId && item.createdAt === today
-  );
+// 토큰에서 studentId 추출
+const getStudentIdFromToken = (req) => {
+  const authHeader = req.headers["authorization"];
+  if (!authHeader) return null;
 
-  if (!todayNews) {
-    return res.status(404).json({
-      message: "오늘 뉴스가 아직 생성되지 않았습니다. 재접속 해주세요.",
-    });
+  const token = authHeader.split(" ")[1];
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    return decoded.studentId;
+  } catch (err) {
+    console.error("토큰 검증 실패:", err);
+    return null;
   }
+};
 
-  res.json({
-    result: todayNews.title,
-  });
+// [GET] 학생 메인 monWord 조회 (임시: 더미 유지)
+exports.getStdMonWord = (req, res) => {
+  return res
+    .status(501)
+    .json({ message: "monWord API는 아직 구현되지 않았습니다." });
+};
+
+// [GET] 학생 메인 monNews 조회
+exports.getStdMonNews = async (req, res) => {
+  try {
+    const studentId = getStudentIdFromToken(req);
+    if (!studentId) {
+      return res.status(401).json({ message: "인증되지 않은 사용자입니다." });
+    }
+
+    const today = formatDate(new Date());
+
+    // 학생 뉴스 조회
+    const student = await StudentNews.findOne({ studentId }).lean();
+    if (!student) {
+      return res.status(404).json({ message: "오늘 뉴스가 없습니다." });
+    }
+
+    // 오늘 할당된 뉴스만 필터링
+    const todayNews = student.newsList.filter(
+      (item) => formatDate(item.assignedAt) === today
+    );
+
+    if (!todayNews.length) {
+      return res.status(404).json({ message: "오늘 뉴스가 없습니다." });
+    }
+
+    // 학생 메인에서는 뉴스 제목만 내려줌
+    res.json({
+      result: todayNews[0].title,
+    });
+  } catch (err) {
+    console.error("getStdMonNews 에러:", err);
+    res.status(500).json({ message: "오늘 뉴스 조회 실패" });
+  }
 };

--- a/src/models/monNews.js
+++ b/src/models/monNews.js
@@ -1,7 +1,12 @@
 const mongoose = require("mongoose");
 
 const studentNewsSchema = new mongoose.Schema({
-  studentId: { type: Number, required: true, index: true },
+  studentId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "Student",
+    required: true,
+    index: true,
+  },
   newsList: [
     {
       mnId: { type: Number, required: true },


### PR DESCRIPTION
## 📌 Related Issue
#46 

## ✨ Work Description
- 학생 JWT 인증 기반 뉴스 배정 / 조회 / 완료 API 구현
- DB 기반 monNews 배정 API 수정
- DB 기반 monNews 조회 API 수정
- DB 기반 monNews 완료 API 수정

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
> AI DB에 오늘 데이터가 있는지 확인하기 (동기화 부분)

| AI DB에 오늘 데이터가 없는 경우 | 있는 경우 |
| --- | --- |
| <img width="492" height="164" alt="image" src="https://github.com/user-attachments/assets/ca4acaed-b1f0-4885-b95c-9a5c773ba945" /> | <img width="910" height="548" alt="image" src="https://github.com/user-attachments/assets/788f7a2d-4368-4a10-8069-d0ebc1d2c008" /> |


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->

